### PR TITLE
Revert "Bump cryptography from 41.0.4 to 42.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ openpyxl==3.1.2
 xlrd==1.2.0
 Pillow==10.2.0  # required by django-imagekit
 psycopg2-binary==2.9.8
-cryptography==42.0.0
+cryptography==41.0.4
 python-dateutil==2.8.2
 pytz==2023.3.post1
 redis==5.0.1


### PR DESCRIPTION
Reverts TheRedHatter/django-DefectDojo#265